### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:18-buster
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install


### PR DESCRIPTION
Changing node version from latest to node:18-buster, Cause node:latest is core dump-ing which uses all the dick space but node:18-buster is working fine without any errors