### PR TITLE
Updated Erela.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "discord.js": "^14.8.0",
     "dompurify": "^3.0.1",
     "dotenv": "^16.0.3",
-    "erela.js": "^2.4.0",
+    "erela.js": "github:Tomato6966/erela.js",
     "erela.js-apple": "^1.2.6",
     "erela.js-deezer": "^1.0.7",
     "erela.js-facebook": "^1.0.4",


### PR DESCRIPTION
Hi there,
as you might have seen, erela.js got unmaintained 1 year ago. Therefore it's running behind some major updates. Some commands like "/music play" often fail due to that. But luckily Tomato6966 has mantained erela.js for one more year and decided now (01.09.2023) to unmaintain it too. Although this fork of erela.js is not unmaintained too, it still works great. It also works with the spotify, deezer and facebook addons of the normal erela.js. I've tested everything I can and I have not found a single Console Error or bug with this version.