### PR TITLE
fix: correct dotenv config path

### DIFF
--- a/src/dev.js
+++ b/src/dev.js
@@ -10,7 +10,7 @@ if (!process.argv[2]) {
     console.log(chalk.red(`[ERROR]`), chalk.white(`>>`), chalk.red(`Developer Badge`), chalk.white(`>>`), chalk.red(`Please provide a member id!`))
     process.exit(1);
 }
-require('dotenv').config('./.env');
+require('dotenv').config({ path: './.env' });
 // Require database
 const mongoose = require('mongoose');
 // Require the model

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const Discord = require('discord.js');
 const chalk = require('chalk');
-require('dotenv').config('./.env');
+require('dotenv').config({ path: './.env' });
 const axios = require('axios');
 // Check if is up to date
 const { version } = require('.././package.json');


### PR DESCRIPTION
The existing call caused a fatal type error. Updated to use config({ path: './.env' }).